### PR TITLE
refac(storage): Create our own storage abstraction

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,6 +18,7 @@ use_repo(
     "com_github_olekukonko_tablewriter",
     "com_github_spf13_cobra",
     "com_github_stretchr_testify",
+    "io_beyondstorage_go_services_fs_v4",
     "io_beyondstorage_go_services_gcs_v3",
     "io_beyondstorage_go_services_s3_v3",
     "io_beyondstorage_go_v5",

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/olekukonko/tablewriter v1.0.9
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
+	go.beyondstorage.io/services/fs/v4 v4.0.0
 	go.beyondstorage.io/services/gcs/v3 v3.0.0
 	go.beyondstorage.io/services/s3/v3 v3.0.1
 	go.beyondstorage.io/v5 v5.0.0
@@ -61,6 +62,7 @@ require (
 	github.com/olekukonko/ll v0.0.9 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/qingstor/go-mime v0.1.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,6 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.36.0/go.mod h1:tgBsFzxwl65BWkuJ/x2EU
 github.com/aws/smithy-go v1.8.1/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/aws/smithy-go v1.22.5 h1:P9ATCXPMb2mPjYBgueqJNCA5S9UfktsW0tTxi+a7eqw=
 github.com/aws/smithy-go v1.22.5/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
-github.com/bazelbuild/rules_go v0.56.0 h1:Ow/oLK5NRhaooY2M2f1+fBiFlGPzmvA4TSaEHisL/RQ=
-github.com/bazelbuild/rules_go v0.56.0/go.mod h1:T90Gpyq4HDFlsrvtQa2CBdHNJ2P4rAu/uUTmQbanzf0=
 github.com/bazelbuild/rules_go v0.56.1 h1:YOyW1J8kdvJl1AzlWrR+qikC6EPiFVbT4l1gjTBfXT0=
 github.com/bazelbuild/rules_go v0.56.1/go.mod h1:T90Gpyq4HDFlsrvtQa2CBdHNJ2P4rAu/uUTmQbanzf0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -306,6 +304,8 @@ github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCko
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/qingstor/go-mime v0.1.0 h1:FhTJtM7TRm9pfgCXpjGUxqwbumGojrgE9ecRz5PXvfc=
+github.com/qingstor/go-mime v0.1.0/go.mod h1:EDwWgaMufg74m7futsF0ZGkdA52ajjAycY+XDeV8M88=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
@@ -346,6 +346,8 @@ go.beyondstorage.io/credential v1.0.0 h1:xJ7hBXmeUE0+rbW+RYZSz4KgHpXvc9g7oQ56f8d
 go.beyondstorage.io/credential v1.0.0/go.mod h1:7KAYievVw4a8u/eLZmnQt65Z91n84sMQj3LFbt8Xous=
 go.beyondstorage.io/endpoint v1.2.0 h1:/7mgKquTykeqJ9op82hso2+WQfECeywGd/Lda1N3tF4=
 go.beyondstorage.io/endpoint v1.2.0/go.mod h1:oZ7Z7HZ7mAo337JBLjuCF/DM66HVEUu6+hw68c3UcLs=
+go.beyondstorage.io/services/fs/v4 v4.0.0 h1:ukDNhoUI1E5x6DDDRUFaA6JbOdrE0taDHKiOemLqnL8=
+go.beyondstorage.io/services/fs/v4 v4.0.0/go.mod h1:gxqLiBwoQQBt1xHTUw2js59tXiYiW67M/RzbP3FwRUc=
 go.beyondstorage.io/services/gcs/v3 v3.0.0 h1:SPMTdsz6As4GSOuX/V8jPxz36qRXv12X7uSkyT7OOfM=
 go.beyondstorage.io/services/gcs/v3 v3.0.0/go.mod h1:4L+8y+igAsIPMwxdO03mjFN8BdsWkvuuLa723rGv64U=
 go.beyondstorage.io/services/s3/v3 v3.0.1 h1:ccNdY88tU3AenaaCAZlYCHD2hZD7ozc9anrmfDse/RU=

--- a/snapshots/go/cmd/snapshots/push.go
+++ b/snapshots/go/cmd/snapshots/push.go
@@ -109,12 +109,8 @@ func (pc *pushCmd) runPush(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	contentLenght, isOk := obj.GetContentLength()
-	if !isOk {
-		log.Printf("failed to get contentLenght of pushed snapshot: %s", obj.Path)
-	}
-
-	log.Printf("pushed snapshot of %d bytes: %s", contentLenght, obj.Path)
+	contentLength := obj.ContentLength
+	log.Printf("pushed snapshot of %d bytes: %s", contentLength, obj.Path)
 
 	return nil
 }

--- a/snapshots/go/pkg/getter/getter.go
+++ b/snapshots/go/pkg/getter/getter.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"path"
 	"strings"
 
@@ -33,53 +32,41 @@ func (g *getter) Get(ctx context.Context, args *GetArgs) (*models.Snapshot, erro
 		return nil, fmt.Errorf("failed to create client: %w", err)
 	}
 
-	snapshotBuffer := new(bytes.Buffer)
 	var snapshotName string
-
 	if !args.SkipTags {
 		tagPath := fmt.Sprintf("tags/%s", args.Name)
-		tagBuffer := new(bytes.Buffer)
-		_, err := store.StatWithContext(ctx, tagPath)
-		if err == nil {
-			_, err = store.ReadWithContext(ctx, tagPath, tagBuffer)
-			if err != nil {
-				return nil, fmt.Errorf("failed to look for tag %s: %w", args.Name, err)
-			}
-			snapshotBytes, err := io.ReadAll(tagBuffer)
-			if err != nil {
-				return nil, fmt.Errorf("failed to read tag: %w", err)
-			}
-			snapshotName = string(snapshotBytes)
 
-			_, err = store.ReadWithContext(ctx, fmt.Sprintf("snapshots/%s.json", snapshotName), snapshotBuffer)
-			if err != nil {
-				return nil, fmt.Errorf("failed to find resolved snapshot %s: %w", snapshotName, err)
+		snapshotBytes, err := store.ReadAll(ctx, tagPath)
+		if err != nil {
+			if !errors.Is(err, storage.ErrNotExist) {
+				return nil, fmt.Errorf("read tag %q: %w", args.Name, err)
 			}
+		} else {
+			snapshotName = string(snapshotBytes)
 		}
 	}
+	if !args.SkipNames && snapshotName == "" {
+		prefix := fmt.Sprintf("snapshots/%s", args.Name)
+		for obj, err := range store.List(ctx, prefix) {
+			if err != nil {
+				return nil, fmt.Errorf("failed to list snapshots with prefix %s: %w", prefix, err)
+			}
 
-	if !args.SkipNames && snapshotBuffer.Len() == 0 {
-		it, err := store.List(fmt.Sprintf("snapshots/%s", args.Name))
-		if err != nil {
-			return nil, fmt.Errorf("cannot create object iterator: %w", err)
-		}
-		if attrs, err := it.Next(); err != nil && errors.Is(err, storage.IteratorDone) {
-			return nil, fmt.Errorf("failed to look for snapshot %s in %s", args.Name, store.String())
-		} else if err == nil {
-			if _, err := it.Next(); err == nil {
+			// If we've already found a snapshot name
+			// and there are still more objects with the same prefix,
+			// the name is ambiguous.
+			if snapshotName != "" {
 				return nil, fmt.Errorf("ambiguous snapshot name: %s", args.Name)
 			}
-			snapshotName = strings.TrimSuffix(path.Base(attrs.Path), ".json")
-		}
 
-		_, err = store.ReadWithContext(ctx, fmt.Sprintf("snapshots/%s.json", snapshotName), snapshotBuffer)
-		if err != nil {
-			return nil, fmt.Errorf("cannot read the snapshot: %w", err)
+			snapshotName = strings.TrimSuffix(path.Base(obj.Path), ".json")
 		}
 	}
 
-	if snapshotBuffer.Len() == 0 {
-		return nil, fmt.Errorf("could not find tag or snapshot: %s", args.Name)
+	snapshotBuffer := new(bytes.Buffer)
+	_, err = store.ReadInto(ctx, fmt.Sprintf("snapshots/%s.json", snapshotName), snapshotBuffer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find resolved snapshot %s: %w", snapshotName, err)
 	}
 
 	snapshot := &models.Snapshot{}

--- a/snapshots/go/pkg/pusher/BUILD.bazel
+++ b/snapshots/go/pkg/pusher/BUILD.bazel
@@ -8,6 +8,5 @@ go_library(
     deps = [
         "//snapshots/go/pkg/models",
         "//snapshots/go/pkg/storage",
-        "@io_beyondstorage_go_v5//types",
     ],
 )

--- a/snapshots/go/pkg/storage/BUILD.bazel
+++ b/snapshots/go/pkg/storage/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "storage",
@@ -7,10 +7,21 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_aws_aws_sdk_go_v2_config//:config",
+        "@io_beyondstorage_go_services_fs_v4//:fs",
         "@io_beyondstorage_go_services_gcs_v3//:gcs",
         "@io_beyondstorage_go_services_s3_v3//:s3",
         "@io_beyondstorage_go_v5//pairs",
         "@io_beyondstorage_go_v5//services",
         "@io_beyondstorage_go_v5//types",
+    ],
+)
+
+go_test(
+    name = "storage_test",
+    srcs = ["storage_test.go"],
+    embed = [":storage"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/snapshots/go/pkg/storage/storage.go
+++ b/snapshots/go/pkg/storage/storage.go
@@ -110,7 +110,15 @@ func newStorager(storageURL string) (types.Storager, error) {
 
 	if u.Scheme == "file" {
 		// Hack: "fs" == "file".
-		// Will be deleted when we switch to gocloud.dev.
+		//
+		// beyondstorage uses "fs://" for local file system storage.
+		// gocloud.dev uses "file://" for the same purpose.
+		//
+		// As we're considering switching to gocloud.dev,
+		// we map "file://" to "fs://" here for beyondstorage
+		// so that we can still use "file://" in tests.
+		// If/when we do switch to gocloud.dev,
+		// the tests won't need to be modified because of this.
 		u.Scheme = "fs"
 	}
 

--- a/snapshots/go/pkg/storage/storage.go
+++ b/snapshots/go/pkg/storage/storage.go
@@ -3,13 +3,19 @@
 package storage
 
 import (
+	"bytes"
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
+	"io"
+	"iter"
 	"net/url"
+	"os"
 	"strings"
 
 	awscfg "github.com/aws/aws-sdk-go-v2/config"
+	_ "go.beyondstorage.io/services/fs/v4"
 	_ "go.beyondstorage.io/services/gcs/v3"
 	_ "go.beyondstorage.io/services/s3/v3"
 	"go.beyondstorage.io/v5/pairs"
@@ -17,9 +23,23 @@ import (
 	"go.beyondstorage.io/v5/types"
 )
 
-var IteratorDone = types.IterateDone
+// Storage stores files in a cloud storage bucket or a local file system.
+type Storage struct {
+	bucket types.Storager
+}
 
-func NewStorage(storageURL string) (types.Storager, error) {
+func NewStorage(storageURL string) (*Storage, error) {
+	storager, err := newStorager(storageURL)
+	if err != nil {
+		return nil, fmt.Errorf("new storager: %w", err)
+	}
+
+	return &Storage{
+		bucket: storager,
+	}, nil
+}
+
+func newStorager(storageURL string) (types.Storager, error) {
 	ctx := context.Background()
 
 	u, err := url.Parse(storageURL)
@@ -88,7 +108,117 @@ func NewStorage(storageURL string) (types.Storager, error) {
 		}
 	}
 
+	if u.Scheme == "file" {
+		// Hack: "fs" == "file".
+		// Will be deleted when we switch to gocloud.dev.
+		u.Scheme = "fs"
+	}
+
 	u.RawQuery = values.Encode()
 
 	return services.NewStoragerFromString(u.String())
+}
+
+// ErrNotExist indicates that a requested path does not exist.
+var ErrNotExist = os.ErrNotExist
+
+// ReadAll reads the entire content of a file at the specified path.
+// Returns [ErrNotExist] if the file does not exist.
+func (s *Storage) ReadAll(ctx context.Context, path string) ([]byte, error) {
+	var buf bytes.Buffer
+	_, err := s.bucket.ReadWithContext(ctx, path, &buf)
+	if err != nil {
+		if errors.Is(err, services.ErrObjectNotExist) {
+			return nil, ErrNotExist
+		}
+		return nil, fmt.Errorf("read all: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// WriteAll writes the entire content of a file at the specified path.
+func (s *Storage) WriteAll(ctx context.Context, path string, bs []byte) error {
+	_, err := s.bucket.WriteWithContext(ctx, path, bytes.NewReader(bs), int64(len(bs)))
+	return err
+}
+
+// ObjectMetadata contains metadata about an object in the storage.
+type ObjectMetadata struct {
+	// Path is the path to the object in the storage
+	// relative to the bucket root.
+	Path string
+
+	// ContentLength is the size of the object in bytes.
+	ContentLength int64
+}
+
+// Stat inspects an object in the storage and returns its metadata.
+// Returns [ErrNotExist] if the object does not exist.
+func (s *Storage) Stat(ctx context.Context, path string) (*ObjectMetadata, error) {
+	attrs, err := s.bucket.StatWithContext(ctx, path)
+	if err != nil {
+		if errors.Is(err, services.ErrObjectNotExist) {
+			return nil, ErrNotExist
+		}
+		return nil, fmt.Errorf("stat: %w", err)
+	}
+
+	contentLength, ok := attrs.GetContentLength()
+	if !ok {
+		return nil, fmt.Errorf("stat: content length not available")
+	}
+
+	return &ObjectMetadata{
+		Path:          path,
+		ContentLength: contentLength,
+	}, nil
+}
+
+// ReadInto reads the content of a file at the specified path
+// and writes it to the provided writer.
+//
+// Returns the number of bytes written and an error if any.
+// Returns [ErrNotExist] if the file does not exist.
+func (s *Storage) ReadInto(ctx context.Context, path string, w io.Writer) (int64, error) {
+	n, err := s.bucket.ReadWithContext(ctx, path, w)
+	if err != nil {
+		if errors.Is(err, services.ErrObjectNotExist) {
+			return 0, ErrNotExist
+		}
+		return 0, fmt.Errorf("new reader: %w", err)
+	}
+	return n, nil
+}
+
+// ListObject is an object in a bucket list iteration.
+type ListObject struct {
+	Path string
+}
+
+// List returns an iterator over objects in the storage
+// with the specified prefix.
+func (s *Storage) List(ctx context.Context, prefix string) iter.Seq2[ListObject, error] {
+	return func(yield func(ListObject, error) bool) {
+		it, err := s.bucket.ListWithContext(ctx, prefix)
+		if err != nil {
+			yield(ListObject{}, fmt.Errorf("list: %w", err))
+			return
+		}
+
+		for {
+			attrs, err := it.Next()
+			if err != nil {
+				if errors.Is(err, types.IterateDone) {
+					return
+				}
+
+				yield(ListObject{}, fmt.Errorf("list: %w", err))
+				return
+			}
+
+			if !yield(ListObject{Path: attrs.Path}, nil) {
+				return
+			}
+		}
+	}
 }

--- a/snapshots/go/pkg/storage/storage_test.go
+++ b/snapshots/go/pkg/storage/storage_test.go
@@ -1,0 +1,134 @@
+package storage
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteAllAndReadAll(t *testing.T) {
+	storage, err := NewStorage("file://" + t.TempDir())
+	require.NoError(t, err)
+
+	contents := []byte("test content")
+
+	require.NoError(t, storage.WriteAll(t.Context(), "test-file.txt", contents))
+
+	got, err := storage.ReadAll(t.Context(), "test-file.txt")
+	require.NoError(t, err)
+
+	assert.Equal(t, contents, got)
+}
+
+func TestStat(t *testing.T) {
+	storage, err := NewStorage("file://" + t.TempDir())
+	require.NoError(t, err)
+
+	contents := []byte("test content for stat")
+
+	require.NoError(t, storage.WriteAll(t.Context(), "test-file.txt", contents))
+
+	got, err := storage.Stat(t.Context(), "test-file.txt")
+	require.NoError(t, err)
+
+	assert.Equal(t, "test-file.txt", got.Path)
+	assert.Equal(t, int64(len(contents)), got.ContentLength)
+}
+
+func TestErrNotFound(t *testing.T) {
+	storage, err := NewStorage("file://" + t.TempDir())
+	require.NoError(t, err)
+
+	t.Run("ReadAll", func(t *testing.T) {
+		_, err := storage.ReadAll(t.Context(), "non-existent-file.txt")
+		assert.ErrorIs(t, err, ErrNotExist)
+	})
+
+	t.Run("Stat", func(t *testing.T) {
+		_, err := storage.Stat(t.Context(), "non-existent-file.txt")
+		assert.ErrorIs(t, err, ErrNotExist)
+	})
+
+	t.Run("ReadInto", func(t *testing.T) {
+		var buf bytes.Buffer
+		_, err := storage.ReadInto(t.Context(), "non-existent-file.txt", &buf)
+		assert.ErrorIs(t, err, ErrNotExist)
+	})
+}
+
+func TestReadInto(t *testing.T) {
+	storage, err := NewStorage("file://" + t.TempDir())
+	require.NoError(t, err)
+
+	contents := []byte("test content for read into")
+
+	require.NoError(t, storage.WriteAll(t.Context(), "test-file.txt", contents))
+
+	var buf bytes.Buffer
+	got, err := storage.ReadInto(t.Context(), "test-file.txt", &buf)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(len(contents)), got)
+	assert.Equal(t, contents, buf.Bytes())
+}
+
+func TestList(t *testing.T) {
+	storage, err := NewStorage("file://" + t.TempDir())
+	require.NoError(t, err)
+
+	files := []string{
+		"foobar",
+		"foobaz",
+		"foo/bar",
+		"foo/qux",
+		"other/file",
+	}
+
+	for _, path := range files {
+		require.NoError(t, storage.WriteAll(t.Context(), path, nil))
+	}
+
+	t.Run("PrefixFile", func(t *testing.T) {
+		t.Skip("beyondstorage FS backend does not support prefix matching")
+
+		var got []string
+		for obj, err := range storage.List(t.Context(), "foo") {
+			require.NoError(t, err)
+			got = append(got, obj.Path)
+		}
+
+		assert.ElementsMatch(t, []string{
+			"foobar",
+			"foobaz",
+		}, got)
+	})
+
+	t.Run("PrefixDir", func(t *testing.T) {
+		var got []string
+		for obj, err := range storage.List(t.Context(), "foo/") {
+			require.NoError(t, err)
+			got = append(got, obj.Path)
+		}
+
+		assert.ElementsMatch(t, []string{
+			"foo/bar",
+			"foo/qux",
+		}, got)
+	})
+
+	t.Run("PrefixDirFile", func(t *testing.T) {
+		t.Skip("beyondstorage FS backend does not support prefix matching")
+
+		var got []string
+		for obj, err := range storage.List(t.Context(), "foo/b") {
+			require.NoError(t, err)
+			got = append(got, obj.Path)
+		}
+
+		assert.ElementsMatch(t, []string{
+			"foo/bar",
+		}, got)
+	})
+}

--- a/snapshots/go/pkg/tagger/BUILD.bazel
+++ b/snapshots/go/pkg/tagger/BUILD.bazel
@@ -5,8 +5,5 @@ go_library(
     srcs = ["tagger.go"],
     importpath = "github.com/cognitedata/bazel-snapshots/snapshots/go/pkg/tagger",
     visibility = ["//visibility:public"],
-    deps = [
-        "//snapshots/go/pkg/storage",
-        "@io_beyondstorage_go_v5//types",
-    ],
+    deps = ["//snapshots/go/pkg/storage"],
 )

--- a/snapshots/private/snapshots.bzl
+++ b/snapshots/private/snapshots.bzl
@@ -39,17 +39,10 @@ def create_tracker_file(ctx, inputs, run = [], tags = [], suffix = ".tracker.jso
     return OutputGroupInfo(change_track_files = depset([tracker_file]))
 
 def _change_tracker_impl(ctx):
-    track_files = []
-    for dep in ctx.attr.deps:
-        track_files.extend(dep.files.to_list())
-
-    # unique track_files
-    track_files = [x for i, x in enumerate(track_files) if i == track_files.index(x)]
-
     return [
         create_tracker_file(
             ctx,
-            track_files,
+            inputs = depset(ctx.files.deps),
             run = [target.label for target in ctx.attr.run],
             tags = ctx.attr.tracker_tags,
             suffix = ".json",


### PR DESCRIPTION
This change refactors the storage layer
to create a custom Storage abstraction around beyondstorage.
I recognize that this is an abstraction around an abstraction,
but this has a couple benefits:

- It makes the contract between bazel-snapshots and storage much clearer,
  e.g. this is the exact functionality we need.
- From a code hygiene perspective,
  this gives us clearer ownership of our storage layer
  versus relying on beyondstorage's APIs in business logic.
- It makes it easier to swap in gocloud.dev without modifying anything else.
  (Change incoming after this PR.)

In writing tests for this layer,
I discovered that beyondstorage's filesystem-backed implementation
of Storage.List does not support prefix matching:
`List(foo)` does not return `foobar`, only contents of directory `foo`.
So I've skipped those tests for now;
they're unskiped in the gocloud.dev implementation,
which has more consistent backend implementations.
