### PR TITLE
refac(pusher): decouple from storage implementation

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,6 +18,7 @@ use_repo(
     "com_github_olekukonko_tablewriter",
     "com_github_spf13_cobra",
     "com_github_stretchr_testify",
+    "io_beyondstorage_go_services_fs_v4",
     "io_beyondstorage_go_services_gcs_v3",
     "io_beyondstorage_go_services_s3_v3",
     "io_beyondstorage_go_v5",

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/olekukonko/tablewriter v1.0.9
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
+	go.beyondstorage.io/services/fs/v4 v4.0.0
 	go.beyondstorage.io/services/gcs/v3 v3.0.0
 	go.beyondstorage.io/services/s3/v3 v3.0.1
 	go.beyondstorage.io/v5 v5.0.0
@@ -61,6 +62,7 @@ require (
 	github.com/olekukonko/ll v0.0.9 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/qingstor/go-mime v0.1.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,6 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.36.0/go.mod h1:tgBsFzxwl65BWkuJ/x2EU
 github.com/aws/smithy-go v1.8.1/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/aws/smithy-go v1.22.5 h1:P9ATCXPMb2mPjYBgueqJNCA5S9UfktsW0tTxi+a7eqw=
 github.com/aws/smithy-go v1.22.5/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
-github.com/bazelbuild/rules_go v0.56.0 h1:Ow/oLK5NRhaooY2M2f1+fBiFlGPzmvA4TSaEHisL/RQ=
-github.com/bazelbuild/rules_go v0.56.0/go.mod h1:T90Gpyq4HDFlsrvtQa2CBdHNJ2P4rAu/uUTmQbanzf0=
 github.com/bazelbuild/rules_go v0.56.1 h1:YOyW1J8kdvJl1AzlWrR+qikC6EPiFVbT4l1gjTBfXT0=
 github.com/bazelbuild/rules_go v0.56.1/go.mod h1:T90Gpyq4HDFlsrvtQa2CBdHNJ2P4rAu/uUTmQbanzf0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -306,6 +304,8 @@ github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCko
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/qingstor/go-mime v0.1.0 h1:FhTJtM7TRm9pfgCXpjGUxqwbumGojrgE9ecRz5PXvfc=
+github.com/qingstor/go-mime v0.1.0/go.mod h1:EDwWgaMufg74m7futsF0ZGkdA52ajjAycY+XDeV8M88=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
@@ -346,6 +346,8 @@ go.beyondstorage.io/credential v1.0.0 h1:xJ7hBXmeUE0+rbW+RYZSz4KgHpXvc9g7oQ56f8d
 go.beyondstorage.io/credential v1.0.0/go.mod h1:7KAYievVw4a8u/eLZmnQt65Z91n84sMQj3LFbt8Xous=
 go.beyondstorage.io/endpoint v1.2.0 h1:/7mgKquTykeqJ9op82hso2+WQfECeywGd/Lda1N3tF4=
 go.beyondstorage.io/endpoint v1.2.0/go.mod h1:oZ7Z7HZ7mAo337JBLjuCF/DM66HVEUu6+hw68c3UcLs=
+go.beyondstorage.io/services/fs/v4 v4.0.0 h1:ukDNhoUI1E5x6DDDRUFaA6JbOdrE0taDHKiOemLqnL8=
+go.beyondstorage.io/services/fs/v4 v4.0.0/go.mod h1:gxqLiBwoQQBt1xHTUw2js59tXiYiW67M/RzbP3FwRUc=
 go.beyondstorage.io/services/gcs/v3 v3.0.0 h1:SPMTdsz6As4GSOuX/V8jPxz36qRXv12X7uSkyT7OOfM=
 go.beyondstorage.io/services/gcs/v3 v3.0.0/go.mod h1:4L+8y+igAsIPMwxdO03mjFN8BdsWkvuuLa723rGv64U=
 go.beyondstorage.io/services/s3/v3 v3.0.1 h1:ccNdY88tU3AenaaCAZlYCHD2hZD7ozc9anrmfDse/RU=

--- a/snapshots/go/cmd/snapshots/BUILD.bazel
+++ b/snapshots/go/cmd/snapshots/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//snapshots/go/pkg/getter",
         "//snapshots/go/pkg/models",
         "//snapshots/go/pkg/pusher",
+        "//snapshots/go/pkg/storage",
         "//snapshots/go/pkg/tagger",
         "@com_github_spf13_cobra//:cobra",
     ],

--- a/snapshots/go/cmd/snapshots/push.go
+++ b/snapshots/go/cmd/snapshots/push.go
@@ -109,12 +109,8 @@ func (pc *pushCmd) runPush(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	contentLenght, isOk := obj.GetContentLength()
-	if !isOk {
-		log.Printf("failed to get contentLenght of pushed snapshot: %s", obj.Path)
-	}
-
-	log.Printf("pushed snapshot of %d bytes: %s", contentLenght, obj.Path)
+	contentLength := obj.ContentLength
+	log.Printf("pushed snapshot of %d bytes: %s", contentLength, obj.Path)
 
 	return nil
 }

--- a/snapshots/go/cmd/snapshots/push.go
+++ b/snapshots/go/cmd/snapshots/push.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cognitedata/bazel-snapshots/snapshots/go/pkg/models"
 	"github.com/cognitedata/bazel-snapshots/snapshots/go/pkg/pusher"
+	"github.com/cognitedata/bazel-snapshots/snapshots/go/pkg/storage"
 )
 
 type pushCmd struct {
@@ -99,12 +100,16 @@ func (pc *pushCmd) runPush(cmd *cobra.Command, args []string) error {
 	log.Printf("workspace: %s", pc.workspacePath)
 	log.Printf("storage:    %s", pc.storageURL)
 
-	pushArgs := pusher.PushArgs{
-		Name:       pc.name,
-		StorageUrl: pc.storageURL,
-		Snapshot:   pc.snapshot,
+	store, err := storage.NewStorage(pc.storageURL)
+	if err != nil {
+		return fmt.Errorf("open storage client: %w", err)
 	}
-	obj, err := pusher.NewPusher().Push(ctx, &pushArgs)
+
+	pushArgs := pusher.PushArgs{
+		Name:     pc.name,
+		Snapshot: pc.snapshot,
+	}
+	obj, err := pusher.NewPusher(store).Push(ctx, &pushArgs)
 	if err != nil {
 		return err
 	}

--- a/snapshots/go/cmd/snapshots/tag.go
+++ b/snapshots/go/cmd/snapshots/tag.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/cognitedata/bazel-snapshots/snapshots/go/pkg/storage"
 	"github.com/cognitedata/bazel-snapshots/snapshots/go/pkg/tagger"
 )
 
@@ -85,12 +86,16 @@ func (tc *tagCmd) runTag(cmd *cobra.Command, args []string) error {
 	log.Printf("snapshot:  %s", tc.snapshotName)
 	log.Printf("tag:       %s", tc.tagName)
 
+	store, err := storage.NewStorage(tc.storageURL)
+	if err != nil {
+		return fmt.Errorf("open storage client: %w", err)
+	}
+
 	tagArgs := tagger.TagArgs{
 		SnapshotName: tc.snapshotName,
-		StorageUrl:   tc.storageURL,
 		TagName:      tc.tagName,
 	}
-	obj, err := tagger.NewTagger().Tag(ctx, &tagArgs)
+	obj, err := tagger.NewTagger(store).Tag(ctx, &tagArgs)
 	if err != nil {
 		return err
 	}

--- a/snapshots/go/pkg/getter/getter.go
+++ b/snapshots/go/pkg/getter/getter.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"path"
 	"strings"
 
@@ -33,53 +32,41 @@ func (g *getter) Get(ctx context.Context, args *GetArgs) (*models.Snapshot, erro
 		return nil, fmt.Errorf("failed to create client: %w", err)
 	}
 
-	snapshotBuffer := new(bytes.Buffer)
 	var snapshotName string
-
 	if !args.SkipTags {
 		tagPath := fmt.Sprintf("tags/%s", args.Name)
-		tagBuffer := new(bytes.Buffer)
-		_, err := store.StatWithContext(ctx, tagPath)
-		if err == nil {
-			_, err = store.ReadWithContext(ctx, tagPath, tagBuffer)
-			if err != nil {
-				return nil, fmt.Errorf("failed to look for tag %s: %w", args.Name, err)
-			}
-			snapshotBytes, err := io.ReadAll(tagBuffer)
-			if err != nil {
-				return nil, fmt.Errorf("failed to read tag: %w", err)
-			}
-			snapshotName = string(snapshotBytes)
 
-			_, err = store.ReadWithContext(ctx, fmt.Sprintf("snapshots/%s.json", snapshotName), snapshotBuffer)
-			if err != nil {
-				return nil, fmt.Errorf("failed to find resolved snapshot %s: %w", snapshotName, err)
+		snapshotBytes, err := store.ReadAll(ctx, tagPath)
+		if err != nil {
+			if !errors.Is(err, storage.ErrNotExist) {
+				return nil, fmt.Errorf("read tag %q: %w", args.Name, err)
 			}
+		} else {
+			snapshotName = string(snapshotBytes)
 		}
 	}
+	if !args.SkipNames && snapshotName == "" {
+		prefix := fmt.Sprintf("snapshots/%s", args.Name)
+		for obj, err := range store.List(ctx, prefix) {
+			if err != nil {
+				return nil, fmt.Errorf("failed to list snapshots with prefix %s: %w", prefix, err)
+			}
 
-	if !args.SkipNames && snapshotBuffer.Len() == 0 {
-		it, err := store.List(fmt.Sprintf("snapshots/%s", args.Name))
-		if err != nil {
-			return nil, fmt.Errorf("cannot create object iterator: %w", err)
-		}
-		if attrs, err := it.Next(); err != nil && errors.Is(err, storage.IteratorDone) {
-			return nil, fmt.Errorf("failed to look for snapshot %s in %s", args.Name, store.String())
-		} else if err == nil {
-			if _, err := it.Next(); err == nil {
+			// If we've already found a snapshot name
+			// and there are still more objects with the same prefix,
+			// the name is ambiguous.
+			if snapshotName != "" {
 				return nil, fmt.Errorf("ambiguous snapshot name: %s", args.Name)
 			}
-			snapshotName = strings.TrimSuffix(path.Base(attrs.Path), ".json")
-		}
 
-		_, err = store.ReadWithContext(ctx, fmt.Sprintf("snapshots/%s.json", snapshotName), snapshotBuffer)
-		if err != nil {
-			return nil, fmt.Errorf("cannot read the snapshot: %w", err)
+			snapshotName = strings.TrimSuffix(path.Base(obj.Path), ".json")
 		}
 	}
 
-	if snapshotBuffer.Len() == 0 {
-		return nil, fmt.Errorf("could not find tag or snapshot: %s", args.Name)
+	snapshotBuffer := new(bytes.Buffer)
+	_, err = store.ReadInto(ctx, fmt.Sprintf("snapshots/%s.json", snapshotName), snapshotBuffer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find resolved snapshot %s: %w", snapshotName, err)
 	}
 
 	snapshot := &models.Snapshot{}

--- a/snapshots/go/pkg/pusher/BUILD.bazel
+++ b/snapshots/go/pkg/pusher/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "pusher",
@@ -8,5 +8,17 @@ go_library(
     deps = [
         "//snapshots/go/pkg/models",
         "//snapshots/go/pkg/storage",
+    ],
+)
+
+go_test(
+    name = "pusher_test",
+    srcs = ["pusher_test.go"],
+    embed = [":pusher"],
+    deps = [
+        "//snapshots/go/pkg/models",
+        "//snapshots/go/pkg/storage",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/snapshots/go/pkg/pusher/BUILD.bazel
+++ b/snapshots/go/pkg/pusher/BUILD.bazel
@@ -8,6 +8,5 @@ go_library(
     deps = [
         "//snapshots/go/pkg/models",
         "//snapshots/go/pkg/storage",
-        "@io_beyondstorage_go_v5//types",
     ],
 )

--- a/snapshots/go/pkg/pusher/pusher_test.go
+++ b/snapshots/go/pkg/pusher/pusher_test.go
@@ -1,0 +1,48 @@
+package pusher
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/cognitedata/bazel-snapshots/snapshots/go/pkg/models"
+	"github.com/cognitedata/bazel-snapshots/snapshots/go/pkg/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPush(t *testing.T) {
+	store, err := storage.NewStorage("file://" + t.TempDir())
+	require.NoError(t, err)
+
+	name := rand.Text()
+
+	pusher := NewPusher(store)
+	md, err := pusher.Push(t.Context(), &PushArgs{
+		Name: name,
+		Snapshot: &models.Snapshot{
+			Labels: map[string]*models.Tracker{
+				"//path/to:tracker": {
+					Digest: "1234abc",
+					Run: []string{
+						"//path/to:release",
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, md.Path, "snapshots/"+name+".json")
+
+	body, err := store.ReadAll(t.Context(), md.Path)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"labels": {
+			"//path/to:tracker": {
+				"digest": "1234abc",
+				"run": [
+					"//path/to:release"
+				]
+			}
+		}
+	}`, string(body))
+}

--- a/snapshots/go/pkg/storage/BUILD.bazel
+++ b/snapshots/go/pkg/storage/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "storage",
@@ -7,10 +7,21 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_aws_aws_sdk_go_v2_config//:config",
+        "@io_beyondstorage_go_services_fs_v4//:fs",
         "@io_beyondstorage_go_services_gcs_v3//:gcs",
         "@io_beyondstorage_go_services_s3_v3//:s3",
         "@io_beyondstorage_go_v5//pairs",
         "@io_beyondstorage_go_v5//services",
         "@io_beyondstorage_go_v5//types",
+    ],
+)
+
+go_test(
+    name = "storage_test",
+    srcs = ["storage_test.go"],
+    embed = [":storage"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/snapshots/go/pkg/storage/storage_test.go
+++ b/snapshots/go/pkg/storage/storage_test.go
@@ -1,0 +1,134 @@
+package storage
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteAllAndReadAll(t *testing.T) {
+	storage, err := NewStorage("file://" + t.TempDir())
+	require.NoError(t, err)
+
+	contents := []byte("test content")
+
+	require.NoError(t, storage.WriteAll(t.Context(), "test-file.txt", contents))
+
+	got, err := storage.ReadAll(t.Context(), "test-file.txt")
+	require.NoError(t, err)
+
+	assert.Equal(t, contents, got)
+}
+
+func TestStat(t *testing.T) {
+	storage, err := NewStorage("file://" + t.TempDir())
+	require.NoError(t, err)
+
+	contents := []byte("test content for stat")
+
+	require.NoError(t, storage.WriteAll(t.Context(), "test-file.txt", contents))
+
+	got, err := storage.Stat(t.Context(), "test-file.txt")
+	require.NoError(t, err)
+
+	assert.Equal(t, "test-file.txt", got.Path)
+	assert.Equal(t, int64(len(contents)), got.ContentLength)
+}
+
+func TestErrNotFound(t *testing.T) {
+	storage, err := NewStorage("file://" + t.TempDir())
+	require.NoError(t, err)
+
+	t.Run("ReadAll", func(t *testing.T) {
+		_, err := storage.ReadAll(t.Context(), "non-existent-file.txt")
+		assert.ErrorIs(t, err, ErrNotExist)
+	})
+
+	t.Run("Stat", func(t *testing.T) {
+		_, err := storage.Stat(t.Context(), "non-existent-file.txt")
+		assert.ErrorIs(t, err, ErrNotExist)
+	})
+
+	t.Run("ReadInto", func(t *testing.T) {
+		var buf bytes.Buffer
+		_, err := storage.ReadInto(t.Context(), "non-existent-file.txt", &buf)
+		assert.ErrorIs(t, err, ErrNotExist)
+	})
+}
+
+func TestReadInto(t *testing.T) {
+	storage, err := NewStorage("file://" + t.TempDir())
+	require.NoError(t, err)
+
+	contents := []byte("test content for read into")
+
+	require.NoError(t, storage.WriteAll(t.Context(), "test-file.txt", contents))
+
+	var buf bytes.Buffer
+	got, err := storage.ReadInto(t.Context(), "test-file.txt", &buf)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(len(contents)), got)
+	assert.Equal(t, contents, buf.Bytes())
+}
+
+func TestList(t *testing.T) {
+	storage, err := NewStorage("file://" + t.TempDir())
+	require.NoError(t, err)
+
+	files := []string{
+		"foobar",
+		"foobaz",
+		"foo/bar",
+		"foo/qux",
+		"other/file",
+	}
+
+	for _, path := range files {
+		require.NoError(t, storage.WriteAll(t.Context(), path, nil))
+	}
+
+	t.Run("PrefixFile", func(t *testing.T) {
+		t.Skip("beyondstorage FS backend does not support prefix matching")
+
+		var got []string
+		for obj, err := range storage.List(t.Context(), "foo") {
+			require.NoError(t, err)
+			got = append(got, obj.Path)
+		}
+
+		assert.ElementsMatch(t, []string{
+			"foobar",
+			"foobaz",
+		}, got)
+	})
+
+	t.Run("PrefixDir", func(t *testing.T) {
+		var got []string
+		for obj, err := range storage.List(t.Context(), "foo/") {
+			require.NoError(t, err)
+			got = append(got, obj.Path)
+		}
+
+		assert.ElementsMatch(t, []string{
+			"foo/bar",
+			"foo/qux",
+		}, got)
+	})
+
+	t.Run("PrefixDirFile", func(t *testing.T) {
+		t.Skip("beyondstorage FS backend does not support prefix matching")
+
+		var got []string
+		for obj, err := range storage.List(t.Context(), "foo/b") {
+			require.NoError(t, err)
+			got = append(got, obj.Path)
+		}
+
+		assert.ElementsMatch(t, []string{
+			"foo/bar",
+		}, got)
+	})
+}

--- a/snapshots/go/pkg/tagger/BUILD.bazel
+++ b/snapshots/go/pkg/tagger/BUILD.bazel
@@ -5,8 +5,5 @@ go_library(
     srcs = ["tagger.go"],
     importpath = "github.com/cognitedata/bazel-snapshots/snapshots/go/pkg/tagger",
     visibility = ["//visibility:public"],
-    deps = [
-        "//snapshots/go/pkg/storage",
-        "@io_beyondstorage_go_v5//types",
-    ],
+    deps = ["//snapshots/go/pkg/storage"],
 )

--- a/snapshots/go/pkg/tagger/BUILD.bazel
+++ b/snapshots/go/pkg/tagger/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "tagger",
@@ -6,4 +6,15 @@ go_library(
     importpath = "github.com/cognitedata/bazel-snapshots/snapshots/go/pkg/tagger",
     visibility = ["//visibility:public"],
     deps = ["//snapshots/go/pkg/storage"],
+)
+
+go_test(
+    name = "tagger_test",
+    srcs = ["tagger_test.go"],
+    embed = [":tagger"],
+    deps = [
+        "//snapshots/go/pkg/storage",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/snapshots/go/pkg/tagger/tagger.go
+++ b/snapshots/go/pkg/tagger/tagger.go
@@ -9,38 +9,41 @@ import (
 	"github.com/cognitedata/bazel-snapshots/snapshots/go/pkg/storage"
 )
 
-type tagger struct{}
+type Storage interface {
+	WriteAll(ctx context.Context, location string, data []byte) error
+	Stat(ctx context.Context, location string) (*storage.ObjectMetadata, error)
+}
 
-func NewTagger() *tagger {
-	return &tagger{}
+var _ Storage = (*storage.Storage)(nil)
+
+type tagger struct {
+	store Storage
+}
+
+func NewTagger(store Storage) *tagger {
+	return &tagger{store: store}
 }
 
 type TagArgs struct {
 	SnapshotName string
-	StorageUrl   string
 	TagName      string
 }
 
-func (*tagger) Tag(ctx context.Context, args *TagArgs) (*storage.ObjectMetadata, error) {
-	store, err := storage.NewStorage(args.StorageUrl)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create storage client: %w", err)
-	}
-
+func (t *tagger) Tag(ctx context.Context, args *TagArgs) (*storage.ObjectMetadata, error) {
 	snapshotLocation := fmt.Sprintf("snapshots/%s.json", args.SnapshotName)
 
-	attrs, err := store.Stat(ctx, snapshotLocation)
+	attrs, err := t.store.Stat(ctx, snapshotLocation)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get snapshot: %w", err)
 	}
 
 	tagContent := []byte(strings.TrimSuffix(path.Base(attrs.Path), ".json"))
 	tagLocation := fmt.Sprintf("tags/%s", args.TagName)
-	if err := store.WriteAll(ctx, tagLocation, tagContent); err != nil {
+	if err := t.store.WriteAll(ctx, tagLocation, tagContent); err != nil {
 		return nil, fmt.Errorf("failed to write tag: %w", err)
 	}
 
-	obj, err := store.Stat(ctx, tagLocation)
+	obj, err := t.store.Stat(ctx, tagLocation)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get object details: %w", err)
 	}

--- a/snapshots/go/pkg/tagger/tagger_test.go
+++ b/snapshots/go/pkg/tagger/tagger_test.go
@@ -1,0 +1,30 @@
+package tagger
+
+import (
+	"testing"
+
+	"github.com/cognitedata/bazel-snapshots/snapshots/go/pkg/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTag(t *testing.T) {
+	store, err := storage.NewStorage("file://" + t.TempDir())
+	require.NoError(t, err)
+
+	require.NoError(t, store.WriteAll(
+		t.Context(), "snapshots/foo.json", []byte(`{"test":"data"}`)))
+
+	tagger := NewTagger(store)
+	md, err := tagger.Tag(t.Context(), &TagArgs{
+		SnapshotName: "foo",
+		TagName:      "latest",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "tags/latest", md.Path)
+
+	gotTag, err := store.ReadAll(t.Context(), "tags/latest")
+	require.NoError(t, err)
+	assert.Equal(t, "foo", string(gotTag))
+}


### PR DESCRIPTION
Change the pusher to accept a storage interface,
allowing for easier testing with a fake storage implementation.

The command implementation is now responsible for
injecting the storage client into the pusher.